### PR TITLE
Non-volatile DB2_CACHE

### DIFF
--- a/xobj_core/_DB2.lsl
+++ b/xobj_core/_DB2.lsl
@@ -12,6 +12,7 @@ list DB2_CACHE;
 #endif
 
 #define db2$rootSend() llMessageLinked(LINK_SET, DB2_UPDATE, mkarr(DB2_CACHE), "")
+#define db2$index() llMessageLinked(LINK_SET, DB2_INDEX, "", "")
 #define db2$get(script, sub) db2(DB2$GET, script, sub, "")
 #define db2$set(sub, val) db2(DB2$SET, llGetScriptName(), sub, val)
 #define db2$setOther(script, sub, val) db2(DB2$SET, script, sub, val)
@@ -31,8 +32,8 @@ string db2(integer task, string script, list sub, string val){
 	#ifndef SCRIPT_IS_ROOT
 	debugCommon("Data to save: "+val);
 	#endif
-	integer pos = llListFindList(DB2_CACHE, [script]); 
-	string dta = (string)llGetLinkMedia(llList2Integer(DB2_CACHE, pos+1), llList2Integer(DB2_CACHE, pos+2), [PRIM_MEDIA_HOME_URL, PRIM_MEDIA_CURRENT_URL]);
+	integer pos = llListFindList(DB2_CACHE, [script]);
+	string dta = llGetSubString((string)llGetLinkMedia(llList2Integer(DB2_CACHE, pos+1), llList2Integer(DB2_CACHE, pos+2), [PRIM_MEDIA_HOME_URL, PRIM_MEDIA_CURRENT_URL]), llStringLength(script), -1);
 	if(task == DB2$GET){
 		if(pos==-1){
 			debugRare("Unable to get data. "+script+" not found in "+llList2CSV(DB2_CACHE));
@@ -40,7 +41,7 @@ string db2(integer task, string script, list sub, string val){
 		}
 		return jVal(dta, sub);
 	}
-	string set = llJsonSetValue(dta,sub,val);
+	string set = script+llJsonSetValue(dta,sub,val);
 	if(!isset(val) && sub == []){
 		if(pos == -1){
 			debugRare("Trying to delete unset shared: "+script);

--- a/xobj_core/_ROOT.lsl
+++ b/xobj_core/_ROOT.lsl
@@ -92,6 +92,7 @@ string getToken(key senderKey, key recipient, string saltrand){
 #define DB2_ADD -5				// [(str)sender, (str)script[, (obj)data]] = (str)script - Data is passed along if this is the first time the script is seen
 #define DB2_UPDATE -6			// str = (arr)data
 #define DB2_DELETE -7			// str = (str)script
+#define DB2_INDEX -8            // NULL - Reindexes DB2_CACHE
 
 // Standard methods
 // These are standard methods used by package modules. Do not define module-specific methods as negative numbers.


### PR DESCRIPTION
I kept running in to issues using DB2 the way I wanted, persistent data between resets and not having the weird requiment of having to do a db2$set() for each script prior to any db2$get() working. Workarounds I had, a dv2$set() in the roots state_entry, worked sometimes, but was inconsisnt and often still resulted in data lose or script-face mismatches.

I've reworked DB2 a little to add the script name as a prefix on the face data, ie:
config{"t":"t","ubm":"96b708c4-8980-4d0d-c4c8-c761b25740b9"}
instead of:
{"t":"t","ubm":"96b708c4-8980-4d0d-c4c8-c761b25740b9"}

db2$index() will trigger the rebuild on the root. The code is mostly shared with DB2_ADD, but will run over every face, the data before the first { is used as the script name in DB2_CACHE.

Might expand on this later to allow more than 2KB per script, but that is likely an edge case that could be handled with db2$setOther() and defining USE_SHARED to a variable.

Ignore the part about DB2_DO_MIGRATE in the commit message, it was something that got left out by accident and did not work as well as I initially thought. The automatic migration was no better at matching scripts to faces and still resulted in data lose.
Its not the biggest flag day xojb has had. :3
