### PR TITLE
Fix for jas Dialog after DB3 update

### DIFF
--- a/xobj_core/classes/packages/jas Dialog.lsl
+++ b/xobj_core/classes/packages/jas Dialog.lsl
@@ -88,10 +88,10 @@ default
                     senderID, 							// UUID to send callback to (or link)
                     llList2String(objects, pos+2), 		// Script to send the callback to
                     DialogMethod$spawn, 				// Method
-                    llList2Json(JSON_OBJECT, [			// CBData
-                        "message", message,  
-                        "menu", llList2Integer(objects, pos+1),
-						"user", id
+                    llList2Json(JSON_ARRAY, [			// CBData
+                        message,  
+                        llList2Integer(objects, pos+1),
+                        id
                     ]), 
                     llList2String(objects, pos+3)			// Callback
                 )  


### PR DESCRIPTION
I thought I had submitted this one a while ago, but apparently not...

Since the callback from jas Dialog returns a keyed json string, the changes from the DB3 update that turned PARAMS from a string into a list breaks reliably reading the callback data.

Cannot do this anymore:
`integer menu = (integer)llJsonGetValue(PARAMS, ["menu"]);
string message = llJsonGetValue(PARAMS, ["message"]);`

Suggest dropping the use of keys on jas Dialog callbacks so fixed indexes of 0 for message, 1 for menu, and 2 for user can be used.
