### PR TITLE
Fixed typo, DB2_ADD > DB3_ADD

### DIFF
--- a/xobj_core/_LM.lsl
+++ b/xobj_core/_LM.lsl
@@ -136,9 +136,9 @@ link_message(integer link, integer nr, string s, key id){
 		#endif
 	#endif
 #else
-	#ifdef SCRIPT_IS_ROOT
-	else if(nr == DB2_ADD){
 // DB2 legacy block end, DB3 start
+	#ifdef SCRIPT_IS_ROOT
+	else if(nr == DB3_ADD){
 	// index all existing tables
 	string sender = j(s, 0);
 	list _to_create = llJson2List(j(s,1));


### PR DESCRIPTION
Trivial change.
Was looking into how DB3 works and using it. Got to db3$addTables and noticed that DB3_ADD it calls isn't handled anywhere. Closest I could find looks like a typo with an additional reference to DB2_ADD. Doesn't cause it to break, but is confusing. Also moved coment up about end of legacy block.
